### PR TITLE
add global statement to remove error

### DIFF
--- a/index.php
+++ b/index.php
@@ -307,6 +307,7 @@
                 'file_permission_denied' => 'Permission denied. You do not have access to this file.',
             ];
             function listDirectory($directory) {
+                global $errorMessages;
                 try{
                     // Attempt to scan the directory
                     $files = scandir($directory);


### PR DESCRIPTION
To remove `Use of unassigned variable '$errorMessages'PHP(PHP1412)` Error on any line with `$errorMessage`.