### PR TITLE
Check current directory's disk space, not the root's

### DIFF
--- a/index.php
+++ b/index.php
@@ -151,8 +151,8 @@
         <i class="fa-solid fa-hard-drive" id="disk-stats"> <span id="disk-space"></span> </i>
         <?php
             // Calculate and format free space in percentage
-            $total_space = disk_total_space("/");
-            $free_space = disk_free_space("/");
+            $total_space = disk_total_space(".");
+            $free_space = disk_free_space(".");
             $free_space_percent = round(($free_space / $total_space) * 100, 2);
             $formatted_free_space_percent = number_format($free_space_percent, 2) . "%";
             


### PR DESCRIPTION
On shared hosting the root directory is usually not accessible:

```
PHP Warning: disk_total_space(): open_basedir restriction in effect. File(/) is not within the allowed path(s): (/home/user/:/tmp:/var/tmp:/opt/alt/php84/usr/share/pear/:/dev/urandom:/usr/local/lib/php/:/usr/local/php84/lib/php/) in public_html/index.php
PHP Warning: disk_free_space(): open_basedir restriction in effect. File(/) is not within the allowed path(s): (/home/user/:/tmp:/var/tmp:/opt/alt/php84/usr/share/pear/:/dev/urandom:/usr/local/lib/php/:/usr/local/php84/lib/php/) in public_html/index.php
PHP Fatal error: Uncaught DivisionByZeroError: Division by zero in public_html/index.php
```

Also, the current directory could be mounted on a partition different than the root.